### PR TITLE
Library cache should be updated after install

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,7 +23,8 @@ platforms:
     driver_config:
       ssh_key: <%= ENV['EC2_SSH_KEY_PATH'] %>
       username: ec2-user
-      image_id: ami-0e289766
+      flavor_id: c3.large
+      image_id: ami-ea6e2a82
       region: us-east-1
       availability_zone: us-east-1b
       security_group_ids: ['ci-testing']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,7 +6,7 @@ end
 
 execute 'Compile, install and clean freeimage' do
   cwd Chef::Config[:file_cache_path]
-  command "unzip freeimage.zip && cd FreeImage && make && make install && make clean"
+  command "unzip freeimage.zip && cd FreeImage && make && make install && make clean && ldconfig"
   action :nothing
   subscribes :run, 'remote_file[freeimage.zip]', :immediately
 end


### PR DESCRIPTION
Library cache should be updated after install for immediate use of installed library files.

Also, updating to 2014.09.2 base ami.